### PR TITLE
Rover coords formula fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+__pycache__
+*.pyc
+*.zip
+*.json
+.idea/
+tests/.cache/v/cache/lastfailed

--- a/code/perception.py
+++ b/code/perception.py
@@ -38,7 +38,7 @@ def rover_coords(binary_img):
     return x_pixel, y_pixel
 
 # Define a function to convert to radial coords in rover space
-def to_radial_coords(x_pixel, y_pixel):
+def to_polar_coords(x_pixel, y_pixel):
     # Convert (x_pixel, y_pixel) to (distance, angle) 
     # in polar coordinates in rover space
     # Calculate distance to each pixel

--- a/code/perception.py
+++ b/code/perception.py
@@ -33,7 +33,7 @@ def rover_coords(binary_img):
     ypos, xpos = binary_img.nonzero()
     # Calculate pixel positions with reference to the rover position being at the 
     # center bottom of the image.  
-    y_pixel = np.absolute(ypos - binary_img.shape[0]).astype(np.float)
+    y_pixel = (binary_img.shape[0] - ypos).astype(np.float)
     x_pixel = (xpos - binary_img.shape[1]/2).astype(np.float)
     return x_pixel, y_pixel
 
@@ -50,7 +50,7 @@ def to_polar_coords(x_pixel, y_pixel):
 # Define a function to map rover space pixels to world space
 def pix_to_world(dist, angles, x_rover, y_rover, yaw_rover):
     # Map pixels from rover space to world coords
-    pix_angles = angles + (yaw_rover * np.pi/180)    
+    pix_angles = angles + (yaw_rover * np.pi/180)
     # Assume a worldmap size of 200 x 200
     world_size = 200
     # Assume factor of 10 scale change between rover and world space

--- a/code/perception.py
+++ b/code/perception.py
@@ -34,7 +34,7 @@ def rover_coords(binary_img):
     # Calculate pixel positions with reference to the rover position being at the 
     # center bottom of the image.  
     y_pixel = np.absolute(ypos - binary_img.shape[0]).astype(np.float)
-    x_pixel = (xpos - binary_img.shape[0]).astype(np.float)
+    x_pixel = (xpos - binary_img.shape[1]/2).astype(np.float)
     return x_pixel, y_pixel
 
 # Define a function to convert to radial coords in rover space


### PR DESCRIPTION
Because of the aspect ratio of the image, it doesn't affect the result, but the `x_pixel` formula should be related to `shape[1]`.  Also, in the `y_pixel` formula, it wasn't clear why the absolute value was necessary.